### PR TITLE
Refactor core setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,10 @@
 
  ```
  line-ai-agent-system/
- ├── config/
- │   └── .env.example         # Environment variable template
+├── config/
+│   └── .env.example         # Environment variable template
+│   ├── database.js          # MongoDB connection helper
+│   └── openai.js            # OpenAI client setup
  ├── controllers/
  │   └── aiReply.js           # Logic to generate and send AI replies
  ├── cron/

--- a/config/database.js
+++ b/config/database.js
@@ -1,0 +1,16 @@
+import mongoose from 'mongoose';
+
+export default async function connectDB(uri) {
+  await mongoose.connect(uri, {
+    useNewUrlParser: true,
+    useUnifiedTopology: true,
+  });
+
+  mongoose.connection.on('connected', () => {
+    console.log('MongoDB connected');
+  });
+
+  mongoose.connection.on('error', (err) => {
+    console.error('MongoDB connection error:', err);
+  });
+}

--- a/config/openai.js
+++ b/config/openai.js
@@ -1,0 +1,7 @@
+import { Configuration, OpenAIApi } from 'openai';
+
+const configuration = new Configuration({ apiKey: process.env.OPENAI_API_KEY });
+
+const openai = new OpenAIApi(configuration);
+
+export default openai;

--- a/controllers/aiReply.js
+++ b/controllers/aiReply.js
@@ -1,11 +1,7 @@
-import { Configuration, OpenAIApi } from 'openai';
+import openai from '../config/openai.js';
 
 import Chat from '../models/Chat.js';
 import buildPrompt from '../utils/promptBuilder.js';
-
-// Setup OpenAI client
-const configuration = new Configuration({ apiKey: process.env.OPENAI_API_KEY });
-const openai = new OpenAIApi(configuration);
 
 
 class AiReplyController {
@@ -38,13 +34,19 @@ class AiReplyController {
     const prompt = await buildPrompt(channelId, userText, history);
 
     // Call OpenAI to generate a response
-    const completion = await openai.createCompletion({
-      model: 'text-davinci-003',
-      prompt,
-      max_tokens: 512,
-      temperature: 0.7,
-    });
-    const botReply = completion.data.choices[0].text.trim();
+    let botReply;
+    try {
+      const completion = await openai.createCompletion({
+        model: 'text-davinci-003',
+        prompt,
+        max_tokens: 512,
+        temperature: 0.7,
+      });
+      botReply = completion.data.choices[0].text.trim();
+    } catch (err) {
+      console.error('OpenAI API error:', err);
+      botReply = 'Sorry, something went wrong.';
+    }
 
     // Save AI reply
     await Chat.create({

--- a/cron/mainLearner.js
+++ b/cron/mainLearner.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 import fs from 'fs/promises';
 import path from 'path';
-import mongoose from 'mongoose';
 import { fileURLToPath } from 'url';
-import { Configuration, OpenAIApi } from 'openai';
+import openai from '../config/openai.js';
+import connectDB from '../config/database.js';
 
 import Chat from '../models/Chat.js';
 
@@ -16,16 +16,9 @@ import dotenv from 'dotenv';
 // Load environment variables from .env at project root
 dotenv.config();
 
-// Setup OpenAI client
-const configuration = new Configuration({ apiKey: process.env.OPENAI_API_KEY });
-const openai = new OpenAIApi(configuration);
-
 async function main() {
   // Connect to MongoDB
-  await mongoose.connect(process.env.MONGODB_URI, {
-    useNewUrlParser: true,
-    useUnifiedTopology: true,
-  });
+  await connectDB(process.env.MONGODB_URI);
 
   const promptsDir = path.resolve(__dirname, '../prompts');
   const files = await fs.readdir(promptsDir);

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import dotenv from 'dotenv';
-import mongoose from 'mongoose';
+import connectDB from './config/database.js';
 
 import lineWebhookRouter from './routes/lineWebhook.js';
 
@@ -14,14 +14,7 @@ const PORT = process.env.PORT || 3000;
 app.use(express.json());
 
 // Connect to MongoDB
-mongoose.connect(process.env.MONGODB_URI, {
-  useNewUrlParser: true,
-  useUnifiedTopology: true,
-});
-mongoose.connection.on('connected', () => {
-  console.log('MongoDB connected');
-});
-mongoose.connection.on('error', (err) => {
+connectDB(process.env.MONGODB_URI).catch((err) => {
   console.error('MongoDB connection error:', err);
 });
 


### PR DESCRIPTION
## Summary
- separate database connection and OpenAI setup into reusable modules
- handle OpenAI errors when generating replies
- use the new helpers in the main server and learner script
- document the additional config files

## Testing
- `node -c index.js`
- `node -c cron/mainLearner.js`
- `node -c controllers/aiReply.js`

------
https://chatgpt.com/codex/tasks/task_e_6849801c00b88326929628d8e63d97d9