### PR TITLE
Add AI Training Dashboard

### DIFF
--- a/dashboard/index.js
+++ b/dashboard/index.js
@@ -1,0 +1,31 @@
+const express = require('express');
+const cors = require('cors');
+const mongoose = require('mongoose');
+const path = require('path');
+require('dotenv').config();
+
+const statsRouter = require('./routes/stats');
+
+const app = express();
+const PORT = process.env.PORT || 4000;
+
+app.use(cors());
+app.use(express.json());
+
+mongoose.connect(process.env.MONGODB_URI, {
+  useNewUrlParser: true,
+  useUnifiedTopology: true,
+});
+
+const db = mongoose.connection;
+db.on('error', (err) => console.error('MongoDB connection error:', err));
+db.once('open', () => console.log('Connected to MongoDB'));
+
+app.use('/api', statsRouter);
+
+app.use(express.static(path.join(__dirname, 'public')));
+
+app.listen(PORT, () => {
+  console.log(`Dashboard server running on port ${PORT}`);
+});
+

--- a/dashboard/models/Chat.js
+++ b/dashboard/models/Chat.js
@@ -1,0 +1,12 @@
+const mongoose = require('mongoose');
+
+const chatSchema = new mongoose.Schema({
+  channelId: String,
+  userId: String,
+  role: { type: String, enum: ['user', 'assistant'], required: true },
+  message: String,
+  timestamp: { type: Date, default: Date.now },
+});
+
+module.exports = mongoose.model('Chat', chatSchema);
+

--- a/dashboard/models/TrainingLog.js
+++ b/dashboard/models/TrainingLog.js
@@ -1,0 +1,9 @@
+const mongoose = require('mongoose');
+
+const trainingLogSchema = new mongoose.Schema({
+  triggeredAt: { type: Date, default: Date.now },
+  summary: String,
+});
+
+module.exports = mongoose.model('TrainingLog', trainingLogSchema);
+

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "ai-training-dashboard",
+  "version": "1.0.0",
+  "main": "index.js",
+  "dependencies": {
+    "express": "^4.18.2",
+    "mongoose": "^6.8.0",
+    "cors": "^2.8.5",
+    "chart.js": "^4.4.0"
+  }
+}
+

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>AI Training Dashboard</title>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 20px; }
+    canvas { max-width: 600px; }
+    table { border-collapse: collapse; width: 100%; margin-top: 20px; }
+    th, td { border: 1px solid #ccc; padding: 8px; text-align: left; }
+  </style>
+</head>
+<body>
+  <h1>AI Training Dashboard</h1>
+  <button id="train">Train Now</button>
+  <p>Latest Training Time: <span id="latest-training">N/A</span></p>
+  <div>
+    <canvas id="pieChart"></canvas>
+  </div>
+  <div>
+    <canvas id="lineChart"></canvas>
+  </div>
+  <table id="chatTable">
+    <thead>
+      <tr><th>Role</th><th>Message</th><th>Time</th></tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+<script>
+async function loadData() {
+  const msgs = await fetch('/api/stats/messages').then(r => r.json());
+  const logs = await fetch('/api/stats/learning').then(r => r.json());
+
+  const userCount = msgs.filter(m => m.role === 'user').length;
+  const assistantCount = msgs.filter(m => m.role === 'assistant').length;
+  const pieCtx = document.getElementById('pieChart').getContext('2d');
+  new Chart(pieCtx, {
+    type: 'pie',
+    data: { labels: ['User', 'Assistant'], datasets: [{ data: [userCount, assistantCount], backgroundColor: ['#36A2EB', '#FF6384'] }] }
+  });
+
+  const countsByDay = {};
+  msgs.forEach(m => {
+    const day = new Date(m.timestamp).toISOString().substring(0,10);
+    countsByDay[day] = (countsByDay[day] || 0) + 1;
+  });
+  const days = Object.keys(countsByDay).sort();
+  const lineCtx = document.getElementById('lineChart').getContext('2d');
+  new Chart(lineCtx, {
+    type: 'line',
+    data: { labels: days, datasets: [{ label: 'Messages', data: days.map(d => countsByDay[d]), fill: false, borderColor: '#36A2EB' }] }
+  });
+
+  const tableBody = document.querySelector('#chatTable tbody');
+  msgs.slice(0,10).forEach(m => {
+    const row = document.createElement('tr');
+    row.innerHTML = `<td>${m.role}</td><td>${m.message}</td><td>${new Date(m.timestamp).toLocaleString()}</td>`;
+    tableBody.appendChild(row);
+  });
+
+  if (logs.length > 0) {
+    document.getElementById('latest-training').textContent = new Date(logs[0].triggeredAt).toLocaleString();
+  }
+}
+
+document.getElementById('train').onclick = async () => {
+  await fetch('/api/train-now', { method: 'POST' });
+  alert('Training started');
+};
+
+loadData();
+</script>
+</body>
+</html>
+

--- a/dashboard/routes/stats.js
+++ b/dashboard/routes/stats.js
@@ -1,0 +1,44 @@
+const express = require('express');
+const { spawn } = require('child_process');
+const path = require('path');
+const Chat = require('../models/Chat');
+const TrainingLog = require('../models/TrainingLog');
+
+const router = express.Router();
+
+router.get('/stats/messages', async (req, res) => {
+  try {
+    const chats = await Chat.find().sort({ timestamp: -1 }).limit(100);
+    res.json(chats);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to fetch messages' });
+  }
+});
+
+router.get('/stats/learning', async (req, res) => {
+  try {
+    const logs = await TrainingLog.find().sort({ triggeredAt: -1 });
+    res.json(logs);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to fetch training logs' });
+  }
+});
+
+router.post('/train-now', (req, res) => {
+  const child = spawn('npm', ['run', 'learn'], {
+    cwd: path.resolve(__dirname, '..', '..'),
+    stdio: 'inherit',
+    shell: true,
+  });
+
+  child.on('error', (err) => {
+    console.error('Failed to start training:', err);
+  });
+
+  res.json({ status: 'started' });
+});
+
+module.exports = router;
+

--- a/dashboard/scripts/start_dashboard.sh
+++ b/dashboard/scripts/start_dashboard.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+node index.js
+


### PR DESCRIPTION
## Summary
- create `dashboard` with Express backend and static frontend
- connect to MongoDB using mongoose
- add Chat and TrainingLog models
- provide stats routes and training trigger
- implement simple dashboard UI with charts
- add helper script to start dashboard server
- include package.json for dashboard dependencies

## Testing
- `node dashboard/index.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_684b1268544c8326bfc6b2e5abcc2f80